### PR TITLE
Fix driver conflicts in generated partitions

### DIFF
--- a/src/eqy_partition.cc
+++ b/src/eqy_partition.cc
@@ -346,6 +346,8 @@ struct Partition
 					for (auto bit : sigmap(conn.second)) {
 						if (bit. wire == nullptr)
 							s.append(bit);
+						else if (c->output(conn.first) && part_inbits.count(bit))
+							s.append(out_mod->addWire(NEW_ID));
 						else if (mapped_bits.count(bit))
 							s.append(mapped_bits.at(bit));
 						else


### PR DESCRIPTION
I noticed driver conflicts in the partitions generated for the picorv32 example. This fixes these, by not connecting any copied cell's outputs to the partition's primary inputs, but I'm not sure it's the correct or best fix.