### PR TITLE
satseq strategy: Use same asymmetric init handling as the sby strategy

### DIFF
--- a/src/eqy.py
+++ b/src/eqy.py
@@ -789,8 +789,10 @@ class EqySatseqStrategy(EqyStrategy):
 
         with open(self.path(partition.name, "run.ys"), "w") as ys_f:
             print(f"read_ilang ../../../partitions/{partition.name}.il", file=ys_f)
+            print(f"formalff -clk2ff -ff2anyinit gate.{partition.name}", file=ys_f)
+            print(f"setundef -anyseq gate.{partition.name}", file=ys_f)
             print(f"miter -equiv -cross -make_assert -ignore_gold_x -flatten gold.{partition.name} gate.{partition.name} miter", file=ys_f)
-            print(f"sat -tempinduct -set-init-undef -set-def-inputs -maxsteps {self.scfg.depth} -prove-asserts -show-public -dump_vcd trace.vcd miter", file=ys_f)
+            print(f"sat -tempinduct -set-init-undef -set-def-formal -set-def-inputs -maxsteps {self.scfg.depth} -prove-asserts -show-public -dump_vcd trace.vcd miter", file=ys_f)
 
 
 class EqySbyStrategy(EqyStrategy):


### PR DESCRIPTION
Implements the following init and constant value handling for the satseq strategy:

  * For gate, x-bits in init values or constants are treated as defined but otherwise unconstrained. Derived signals still use 3-valued semantics.

  * For gold, x-bits are kept as is for checking using 3-valued semantics.

This is the same handling that is used by the sby strategy with xprop on (the default).

Depends on YosysHQ/yosys#3565 for the -set-def-formal option of the sat command.