### PR TITLE
Rename `satseq` strategy to `sat`

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -250,7 +250,7 @@ strategy as an argument.
 
    [strategy simple]
    apply axi_xbar_*
-   use satseq
+   use sat
    depth 10
 
 use statements
@@ -259,7 +259,7 @@ use statements
 The ``use strategy_type`` command selects a strategy type for this strategy. Each
 strategy type defines its own custom commands for the strategy section. For example,
 the ``depth`` command in the example above is a custom command only understood by
-the ``satseq`` strategy type.
+the ``sat`` strategy type.
 
 apply and noapply
 .................

--- a/examples/picorv32/picorv32_modified.eqy
+++ b/examples/picorv32/picorv32_modified.eqy
@@ -30,5 +30,5 @@ group decoded_*
 group cpuregs[]
 
 [strategy simple]
-use satseq
+use sat
 depth 3

--- a/examples/simple/aliases.eqy
+++ b/examples/simple/aliases.eqy
@@ -7,5 +7,5 @@ read_verilog -DGATE aliases.sv
 prep -top aliases
 
 [strategy simple]
-use satseq
+use sat
 depth 10

--- a/examples/simple/counter.eqy
+++ b/examples/simple/counter.eqy
@@ -9,5 +9,5 @@ read_verilog counter.sv
 synth -top counter
 
 [strategy simple]
-use satseq
+use sat
 depth 10

--- a/examples/simple/ex_amend.eqy
+++ b/examples/simple/ex_amend.eqy
@@ -16,5 +16,5 @@ join Y
 amend X
 
 [strategy simple]
-use satseq
+use sat
 depth 10

--- a/examples/simple/ex_bind.eqy
+++ b/examples/simple/ex_bind.eqy
@@ -14,5 +14,5 @@ bind Y
 solo *
 
 [strategy simple]
-use satseq
+use sat
 depth 10

--- a/examples/simple/ex_group.eqy
+++ b/examples/simple/ex_group.eqy
@@ -13,5 +13,5 @@ solo *
 group X Y
 
 [strategy simple]
-use satseq
+use sat
 depth 10

--- a/examples/simple/ex_join.eqy
+++ b/examples/simple/ex_join.eqy
@@ -13,5 +13,5 @@ solo *
 join X
 
 [strategy simple]
-use satseq
+use sat
 depth 10

--- a/examples/simple/fsm.eqy
+++ b/examples/simple/fsm.eqy
@@ -21,5 +21,5 @@ prep -top top
 1000 11
 
 [strategy simple]
-use satseq
+use sat
 depth 10

--- a/src/eqy.py
+++ b/src/eqy.py
@@ -136,7 +136,7 @@ read -sv {3}
 prep -top {1}
 
 [strategy simple]
-use satseq
+use sat
 depth 10
 """.format(*ctx.args.init_config_file))
         print("eqy template config written to '{}'.".format(ctx.args.init_config_file[0]), file=sys.stderr)
@@ -851,7 +851,7 @@ class EqyDummyStrategy(EqyStrategy):
             print(f"echo \"Setting unknown status for partition '{partition.name}' via dummy strategy '{self.name}'\"", file=run_f)
 
 
-class EqySatseqStrategy(EqyStrategy):
+class EqySatStrategy(EqyStrategy):
     default_scfg = dict(depth=5)
     parse_opt_depth = EqyStrategy.int_opt_parser
 
@@ -969,7 +969,7 @@ class EqySbyStrategy(EqyStrategy):
 
 strategy_types = {
     "dummy": EqyDummyStrategy,
-    "satseq": EqySatseqStrategy,
+    "sat": EqySatStrategy,
     "sby": EqySbyStrategy,
     # add strategies here
 }


### PR DESCRIPTION
It's not using `sat -seq` anymore but `sat -tempinduct`, but that detail doesn't have to be in the strategy name at all.