### PR TITLE
Redo JSON output to use PrettyJson

### DIFF
--- a/tests/python/Makefile
+++ b/tests/python/Makefile
@@ -1,4 +1,5 @@
 EQY := eqy
+PYTHON_TEMPDIR := $(shell python3 -c "import tempfile; print(tempfile.gettempdir())")
 
 test: failing_tests passing_tests
 
@@ -8,7 +9,7 @@ passing_tests:
 	@rm -rf counter/ counter.bak*/; $(EQY) counter.eqy > /dev/null
 	@$(EQY) -b counter.eqy > /dev/null # 1st counter
 	@$(EQY) -b counter.eqy > /dev/null # 2nd counter
-	@$(EQY) -t counter.eqy | grep -i "make -C /tmp/" # Use temp
+	@$(EQY) -t counter.eqy | grep -i "make -C $(PYTHON_TEMPDIR)" # Use temp
 	@rm -rf counter/ counter.bak*/; $(EQY) counter.eqy -d counter | grep -i "make -C counter -f strategies.mk"   # setting workdir
 	@$(EQY) -c counter.eqy --purge "counter.state/simple" 2>&1 | grep -i "Removing" # continue with purge
 	@$(EQY) -f counter_cells.eqy 2>&1 | grep -i "counter.state__SDFF_PP0__Q" # matching cells


### PR DESCRIPTION
* `src/eqy_partition.cc::Partition::write`: Replaced ofstream with PrettyJson from `kernel/json.h` to fix string escaping issues
* `tests/python/Makefile`: Fixed "Use temp" test- according to https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir, the path returned by `mkdtemp` is not always in `/tmp` depending on the user's environment variables

---
Resolves #43 