### PR TITLE
Fix escaping for dependent shell patterns

### DIFF
--- a/src/eqy.py
+++ b/src/eqy.py
@@ -474,6 +474,9 @@ class Pattern:
                 else:
                     regex.append(f"({tok})")
                 continue
+            if tok == "\\":
+                regex.append(tok + next(chars))
+                continue
             regex.append(tok)
         return re.compile("".join(regex))
 


### PR DESCRIPTION
Without this, when replacing punctuation into dependent shell patterns, the shell-to-regexp conversion breaks the already performed regexp escaping. This makes it pass through escape sequences as such.