### PR TITLE
Add --version option based on git describe

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/.gittag export-subst

--- a/.gittag
+++ b/.gittag
@@ -1,0 +1,1 @@
+$Format:%(describe)$

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,12 @@ ifeq ($(OS), Windows_NT)
 PYTHON = $(shell cygpath -w -m $(PREFIX)/bin/python3)
 endif
 
+ifeq ($(file < .gittag),$$Format:%(describe)$$)
+YOSYS_RELEASE_VERSION := EQY $(shell git describe --dirty)
+else
+YOSYS_RELEASE_VERSION := EQY $(file < .gittag)
+endif
+
 build: src/eqy_combine.so src/eqy_partition.so src/eqy_recode.so
 
 DEBUG_CXXFLAGS :=
@@ -41,10 +47,12 @@ install: src/eqy_combine.so src/eqy_partition.so src/eqy_recode.so
 	cp src/eqy_recode.so $(DESTDIR)$(PREFIX)/share/yosys/plugins/
 ifeq ($(OS), Windows_NT)
 	sed -e 's|##yosys-sys-path##|sys.path += [os.path.dirname(__file__) + p for p in ["/share/python3", "/../share/yosys/python3"]]|;' \
+		-e "s|##yosys-release-version##|release_version = '$(YOSYS_RELEASE_VERSION)'|;" \
 		-e "s|#!/usr/bin/env python3|#!$(PYTHON)|" < src/eqy.py > $(DESTDIR)$(PREFIX)/bin/eqy-script.py
 	gcc -DGUI=0 -O -s -o $(DESTDIR)$(PREFIX)/bin/eqy.exe extern/launcher.c
 else
-	sed 's|##yosys-sys-path##|sys.path += [os.path.dirname(__file__) + p for p in ["/share/python3", "/../share/yosys/python3"]]|;' < src/eqy.py > $(DESTDIR)$(PREFIX)/bin/eqy
+	sed -e 's|##yosys-sys-path##|sys.path += [os.path.dirname(__file__) + p for p in ["/share/python3", "/../share/yosys/python3"]]|;' \
+		-e "s|##yosys-release-version##|release_version = '$(YOSYS_RELEASE_VERSION)'|;" < src/eqy.py > $(DESTDIR)$(PREFIX)/bin/eqy
 	chmod +x $(DESTDIR)$(PREFIX)/bin/eqy
 endif
 

--- a/src/eqy.py
+++ b/src/eqy.py
@@ -25,6 +25,9 @@ import click, json, collections
 
 from eqy_job import EqyJob, EqyTask
 
+release_version = 'unknown EQY version'
+##yosys-release-version##
+
 def exit_with_error(error, retcode=1):
     print("ERROR:", error, file=sys.stderr)
     exit(retcode)
@@ -101,6 +104,8 @@ def parse_args(ctx):
     exes.add_argument("--pono", metavar="<path_to_executable>",
             action=DictAction, dest="exe_paths",
             help="configure which executable to use for the respective tool")
+
+    parser.add_argument('--version', action='version', version=release_version)
 
     ctx.args = parser.parse_args()
 
@@ -1183,7 +1188,7 @@ def main():
         build_recode(ctx.args, ctx, ctx.job)
     else:
         shutil.copyfile(f"{ctx.args.workdir}/gate.il", f"{ctx.args.workdir}/gate_recoded.il")
-        
+
     build_combined(ctx.args, ctx, ctx.job)
 
     ctx.gold_ids = read_ids(ctx.args.workdir + "/gold.ids")


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

EQY assumes that it is used together with a compatible yosys version, but does not offer any easy way to tell what that compatible yosys version is. Users of the OSS Cad Suite or Tabby CAD automatically have matching versions, and we create tags corresponding to the yosys version in this repository, but users that manually installed EQY in the past have no way to check which version they installed. This adds a `--version` option that prints the `git describe` output identifying the installed version.

_Explain how this is achieved._

I added a new `##yosys-release-version##` placeholder following `release_version = 'unknown EQY version'` to the source code and updated the makefile to substitute the placeholder with a statement overwriting the `release_version` variable.

I also added a `.gittag` file and ` .gitattribtues` file so git will remember the tagged version when creating source archives.

The makefile first checks the .gittag file and uses that when it includes a version string, falling back to running `git describe --dirty` otherwise.

_If applicable, please suggest to reviewers how they can test the change._

It would be good to check that this works correctly in the context of the OSS Cad Suite builds.