### PR TITLE
Add support for the imctk-eqy-engine ("use imctk")

### DIFF
--- a/src/eqy.py
+++ b/src/eqy.py
@@ -976,10 +976,38 @@ class EqySbyStrategy(EqyStrategy):
             """[1:-1]), file=run_f)
 
 
+class EqyImctkStrategy(EqySbyStrategy):
+    default_scfg = dict(
+        engine='aiger imctk-eqy-engine',
+        depth=5,
+        xprop=True,
+        rarity_sim_rounds=5,
+        window_min=3,
+        window_max=8,
+        timeout=None,
+        option=()
+    )
+    parse_opt_rarity_sim_rounds = EqyStrategy.int_opt_parser
+    parse_opt_window_min = EqyStrategy.int_opt_parser
+    parse_opt_window_max = EqyStrategy.int_opt_parser
+    def parse_opt_engine(self, *line):
+        self.parse_other_option(*line)
+
+
+    def write(self, job, partition):
+        self.scfg.engine = ' '.join([
+            'aiger imctk-eqy-engine',
+            f'--rarity-sim-rounds {self.scfg.rarity_sim_rounds}',
+            f'--window-min {self.scfg.window_min}',
+            f'--window-max {self.scfg.window_max}',
+        ])
+        super().write(job, partition)
+
 strategy_types = {
     "dummy": EqyDummyStrategy,
     "sat": EqySatStrategy,
     "sby": EqySbyStrategy,
+    "imctk": EqyImctkStrategy
     # add strategies here
 }
 


### PR DESCRIPTION
_What are the reasons/motivation for this change?_

Supporting the imctk-eqy-engine. This also requires https://github.com/YosysHQ/sby/pull/297 and the imctk-eqy-engine built from the imctk's wip branch (will update this when there's a PR on the imctk repository).

_Explain how this is achieved._

By creating a strategy derived from the SBY strategy and adding imctk-eqy-engine to the aiger engines SBY knows about.

_If applicable, please suggest to reviewers how they can test the change._

The "picorv32_vivado.eqy" example can be changed to use the "use imctk" strategy instead.