### PR TITLE
Makefile: allow PREFIX override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 DESTDIR =
-PREFIX = /usr/local
+PREFIX ?= /usr/local
 PROGRAM_PREFIX =
 YOSYS_CFGFLAGS =
 


### PR DESCRIPTION
This PR allows users to set whatever directory to install eqy to. Without this PR, eqy can't be run on nixOS, as the executable is created in the install step.

```
$ ls /usr/local
ls: cannot access '/usr/local': No such file or directory
```
