### PR TITLE
Add sleep import to eqy_job.py

### DIFF
--- a/src/eqy_job.py
+++ b/src/eqy_job.py
@@ -3,7 +3,7 @@ if os.name == "posix":
     import resource, fcntl
 import subprocess, signal
 from select import select
-from time import time, localtime
+from time import time, localtime, sleep
 import click
 
 

--- a/src/eqy_job.py
+++ b/src/eqy_job.py
@@ -5,7 +5,7 @@ import subprocess, signal
 from select import select
 if os.name == "posix":
     from time import time, localtime
-else
+else:
     from time import time, localtime, sleep
 import click
 

--- a/src/eqy_job.py
+++ b/src/eqy_job.py
@@ -3,7 +3,10 @@ if os.name == "posix":
     import resource, fcntl
 import subprocess, signal
 from select import select
-from time import time, localtime, sleep
+if os.name == "posix":
+    from time import time, localtime
+else
+    from time import time, localtime, sleep
 import click
 
 

--- a/src/eqy_job.py
+++ b/src/eqy_job.py
@@ -3,10 +3,7 @@ if os.name == "posix":
     import resource, fcntl
 import subprocess, signal
 from select import select
-if os.name == "posix":
-    from time import time, localtime
-else:
-    from time import time, localtime, sleep
+from time import time, localtime, sleep
 import click
 
 


### PR DESCRIPTION
I encountered the following error when trying eqy within oss-cad-suite installed on Windows 11.  

> Traceback (most recent call last):  
>  File "C:\StandalonePrograms\02_oss-cad-suite\bin\eqy-script.py", line 1260, in <module>  
>    main()  
>  File "C:\StandalonePrograms\02_oss-cad-suite\bin\eqy-script.py", line 1213, in main  
>    build_gate_gold(ctx.args, ctx, ctx.job)  
>  File "C:\StandalonePrograms\02_oss-cad-suite\bin\eqy-script.py", line 319, in build_gate_gold  
>    job.run()  
>  File "C:\StandalonePrograms\02_oss-cad-suite\bin/../share/yosys/python3\eqy_job.py", line 670, in run  
>    self.taskloop()  
>  File "C:\StandalonePrograms\02_oss-cad-suite\bin/../share/yosys/python3\eqy_job.py", line 265, in taskloop  
>    sleep(0.1)  
>    ^^^^^  
>NameError: name 'sleep' is not defined  

 After investigating, I found that `sleep()` from the `time` library is not imported.   

Therefore, I would like to propose a fix.  

Thanks.
