### PR TITLE
Add timeout option to EqySatStrategy

### DIFF
--- a/src/eqy.py
+++ b/src/eqy.py
@@ -855,8 +855,9 @@ class EqyDummyStrategy(EqyStrategy):
 
 
 class EqySatStrategy(EqyStrategy):
-    default_scfg = dict(depth=5)
+    default_scfg = dict(depth=5, timeout=None)
     parse_opt_depth = EqyStrategy.int_opt_parser
+    parse_opt_timeout = EqyStrategy.int_opt_parser
 
     def partition_supported(self, job, partition):
         if 'memory' in partition.attributes:
@@ -870,10 +871,13 @@ class EqySatStrategy(EqyStrategy):
                 yosys -ql run.log run.ys
                 if grep "SAT temporal induction proof finished - model found for base case: FAIL!" run.log > /dev/null ; then
                 \techo FAIL > status
-                \techo "Could not prove equivalence of partition '{partition.name}' using strategy '{self.name}'"
+                \techo "Could not prove equivalence of partition '{partition.name}' using strategy '{self.name}': partitions not equivalent"
                 elif grep "Reached maximum number of time steps -> proof failed." run.log > /dev/null ; then
                 \techo UNKNOWN > status
-                \techo "Could not prove equivalence of partition '{partition.name}' using strategy '{self.name}'"
+                \techo "Could not prove equivalence of partition '{partition.name}' using strategy '{self.name}': equivalence unknown"
+                elif grep "Interrupted SAT solver: TIMEOUT!" run.log > /dev/null ; then
+                \techo UNKNOWN > status
+                \techo "Could not prove equivalence of partition '{partition.name}' using strategy '{self.name}': timeout"
                 elif grep "Induction step proven: SUCCESS!" run.log > /dev/null ; then
                 \techo PASS > status
                 \techo "Proved equivalence of partition '{partition.name}' using strategy '{self.name}'"
@@ -896,6 +900,7 @@ class EqySatStrategy(EqyStrategy):
             print(f"setundef -anyseq gate.{partition.name}", file=ys_f)
             print(f"flatten -wb; dffunmap; opt_expr -keepdc -undriven; opt_clean", file=ys_f)
             print(f"sat -tempinduct -set-init-undef -set-def-formal -set-def-inputs -maxsteps {self.scfg.depth} " + \
+                    (f"-timeout {self.scfg.timeout} " if self.scfg.timeout else "") + \
                     f"-set-assumes -prove-asserts -show-public -dump_vcd trace.vcd miter", file=ys_f)
 
 

--- a/tests/python/.gitignore
+++ b/tests/python/.gitignore
@@ -7,6 +7,7 @@ generate.eqy
 /splitnets/
 /picorv32_vivado/
 /timeout/
+/sat_timeout/
 /problem_occured/
 /failed_partition/
 /equivalence_problem/

--- a/tests/python/.gitignore
+++ b/tests/python/.gitignore
@@ -8,6 +8,7 @@ generate.eqy
 /picorv32_vivado/
 /timeout/
 /sat_timeout/
+/sat_no_timeout/
 /problem_occured/
 /failed_partition/
 /equivalence_problem/

--- a/tests/python/Makefile
+++ b/tests/python/Makefile
@@ -15,6 +15,7 @@ passing_tests:
 	@$(EQY) - < counter.eqy 2>&1 | grep -i "Cannot derive workdir name from config file name" # stdin
 	@$(EQY) -f counter.eqy --setup | grep -i "DONE (UNKNOWN, rc=0)" # setup only
 	@$(EQY) -f failed_partition.eqy > /dev/null
+	@$(EQY) -f sat_no_timeout.eqy 2>&1 | grep -i "DONE (PASS, rc=0)"
 
 failing_tests:
 	@$(EQY) 2>&1 | grep -i "No config file given"

--- a/tests/python/Makefile
+++ b/tests/python/Makefile
@@ -22,6 +22,7 @@ failing_tests:
 	@$(EQY) -f error_verilog.eqy 2>&1 | grep -i "Reading sources failed"
 	@$(EQY) -f read_source_fail.eqy --yosys /tmp/yosys 2>&1 | grep -i "Reading sources failed"
 	@timeout 2s $(EQY) -f timeout.eqy 2>&1 | grep -i "Keyboard interrupt or external termination signal"
+	@$(EQY) -f sat_timeout.eqy 2>&1 | grep -i "Could not prove equivalence of partition 'picorv32.alu_out' using strategy 'simple': timeout"
 	@$(EQY) counter.eqy -t -d counter 2>&1 | grep -i "Cannot use -d with -t"
 	@mkdir -p counter; $(EQY) counter.eqy 2>&1 | grep -i "Directory 'counter' already exists"
 	@$(EQY) counter.eqy -d counter 2>&1 | grep -i "Directory 'counter' already exists" # setting workdir when exist
@@ -52,6 +53,6 @@ failing_tests:
 	@$(EQY) -f missing_gold_section.eqy 2>&1 | grep -i "section \[gold\] missing"
 
 clean:
-	@rm -rf counter/ counter.bak*/ counter_cells/ error_verilog/ generate.eqy picorv32_vivado/ read_source_fail/ timeout/ splitnets/ problem_occured/ failed_partition/ equivalence_problem/ syntax_error_partition/ syntax_error_collect/
+	@rm -rf counter/ counter.bak*/ counter_cells/ error_verilog/ generate.eqy picorv32_vivado/ read_source_fail/ timeout/ sat_timeout/ splitnets/ problem_occured/ failed_partition/ equivalence_problem/ syntax_error_partition/ syntax_error_collect/
 
 .PHONY: test clean

--- a/tests/python/sat_no_timeout.eqy
+++ b/tests/python/sat_no_timeout.eqy
@@ -1,0 +1,15 @@
+[options]
+
+[gold]
+read_verilog counter.sv
+prep -top counter
+memory_map -formal
+
+[gate]
+read_verilog counter.sv
+synth -top counter
+
+[strategy simple]
+use sat
+depth 10
+timeout 1000

--- a/tests/python/sat_timeout.eqy
+++ b/tests/python/sat_timeout.eqy
@@ -1,0 +1,18 @@
+[options]
+
+[gold]
+read_verilog ../../examples/picorv32/picorv32.v
+prep -top picorv32
+memory_map -formal
+
+[gate]
+read_verilog ../../examples/picorv32/picorv32.v
+synth -top picorv32
+
+[collect *]
+group *
+
+[strategy simple]
+use sat
+depth 10
+timeout 1


### PR DESCRIPTION
_What are the reasons/motivation for this change?_
The yosys `sat` command is low-overhead but AFAIK scales poorly compared to the solvers available in SBY. By adding a timeout option, it's possible to use it for a quick first pass to solve easy partitions, but move on to more powerful strategies after a short time.

_Explain how this is achieved._
Mirror the timeout option for the SBY strategy.

I also copied the more detailed messages explaining the 3 different "could not prove" cases from the SBY strategy.

_If applicable, please suggest to reviewers how they can test the change._
Added a test that is deliberately difficult and set a very short timeout. A test of strategy simple without timeout already exists. Also added a test with a simple design and a very large timeout confirming normal non-timeout completion.

Would like to add a test of successful completion of the second strategy after the first times out, but I don't have an example with such different performance between sat and sby that this would be doable within a reasonable runtime.